### PR TITLE
update CMakeLists.txt to 3.5, fix pkg_check (vorbis and ogg) and add --with-pic use

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,7 @@
+cmake_minimum_required(VERSION 3.5)
 project(audioencoder.vorbis)
 
-cmake_minimum_required(VERSION 2.6)
-
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
-
-enable_language(CXX)
 
 find_package(Kodi REQUIRED)
 find_package(Ogg REQUIRED)

--- a/FindOgg.cmake
+++ b/FindOgg.cmake
@@ -7,16 +7,15 @@
 
 find_package(PkgConfig)
 if(PKG_CONFIG_FOUND)
-  pkg_check_modules (OGG ogg)
-  list(APPEND OGG_INCLUDE_DIRS ${OGG_INCLUDEDIR})
+  pkg_check_modules(PC_OGG ogg QUIET)
 endif()
 
-if(NOT OGG_FOUND)
-  find_path(OGG_INCLUDE_DIRS ogg/ogg.h)
-  find_library(OGG_LIBRARIES ogg)
-endif()
+find_path(OGG_INCLUDE_DIRS ogg/ogg.h
+                           PATHS ${PC_OGG_INCLUDEDIR})
+find_library(OGG_LIBRARIES ogg
+                           PATHS ${PC_OGG_LIBDIR})
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(Ogg DEFAULT_MSG OGG_INCLUDE_DIRS OGG_LIBRARIES)
+find_package_handle_standard_args(Ogg REQUIRED_VARS OGG_INCLUDE_DIRS OGG_LIBRARIES)
 
 mark_as_advanced(OGG_INCLUDE_DIRS OGG_LIBRARIES)

--- a/FindVorbis.cmake
+++ b/FindVorbis.cmake
@@ -7,16 +7,15 @@
 
 find_package(PkgConfig)
 if(PKG_CONFIG_FOUND)
-  pkg_check_modules (VORBIS vorbis)
-  list(APPEND VORBIS_INCLUDE_DIRS ${VORBIS_INCLUDEDIR})
+  pkg_check_modules(PC_VORBIS vorbis QUIET)
 endif()
 
-if(NOT VORBIS_FOUND)
-  find_path(VORBIS_INCLUDE_DIRS vorbis/vorbisenc.h)
-  find_library(VORBIS_LIBRARIES vorbis)
-endif()
+find_path(VORBIS_INCLUDE_DIRS vorbis/vorbisenc.h
+                              PATHS ${PC_VORBIS_INCLUDEDIR})
+find_library(VORBIS_LIBRARIES vorbis
+                              PATHS ${PC_VORBIS_LIBDIR})
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(Vorbis DEFAULT_MSG VORBIS_INCLUDE_DIRS VORBIS_LIBRARIES)
+find_package_handle_standard_args(Vorbis REQUIRED_VARS VORBIS_INCLUDE_DIRS VORBIS_LIBRARIES)
 
 mark_as_advanced(VORBIS_INCLUDE_DIRS VORBIS_LIBRARIES)

--- a/FindVorbisEnc.cmake
+++ b/FindVorbisEnc.cmake
@@ -7,16 +7,15 @@
 
 find_package(PkgConfig)
 if(PKG_CONFIG_FOUND)
-  pkg_check_modules (VORBISENC vorbisenc)
-  list(APPEND VORBISENC_INCLUDE_DIRS ${VORBISENC_INCLUDEDIR})
+  pkg_check_modules(PC_VORBISENC vorbisenc QUIET)
 endif()
 
-if(NOT VORBISENC_FOUND)
-  find_path(VORBISENC_INCLUDE_DIRS vorbis/vorbisenc.h)
-  find_library(VORBISENC_LIBRARIES vorbisenc)
-endif()
+find_path(VORBISENC_INCLUDE_DIRS vorbis/vorbisenc.h
+                                 PATHS ${PC_VORBISENC_INCLUDEDIR})
+find_library(VORBISENC_LIBRARIES vorbisenc
+                                 PATHS ${PC_VORBISENC_LIBDIR})
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(VorbisEnc DEFAULT_MSG VORBISENC_INCLUDE_DIRS VORBISENC_LIBRARIES)
+find_package_handle_standard_args(VorbisEnc REQUIRED_VARS VORBISENC_INCLUDE_DIRS VORBISENC_LIBRARIES)
 
 mark_as_advanced(VORBISENC_INCLUDE_DIRS VORBISENC_LIBRARIES)

--- a/depends/common/ogg/CMakeLists.txt
+++ b/depends/common/ogg/CMakeLists.txt
@@ -1,6 +1,5 @@
+cmake_minimum_required(VERSION 3.5)
 project(ogg)
-
-cmake_minimum_required(VERSION 2.8)
 
 include(ExternalProject)
 externalproject_add(ogg

--- a/depends/common/ogg/CMakeLists.txt
+++ b/depends/common/ogg/CMakeLists.txt
@@ -9,7 +9,7 @@ externalproject_add(ogg
                       --prefix=${OUTPUT_DIR}
                       --enable-static
                       --disable-shared
-                      "CFLAGS=-fPIC -DPIC -O2"
+                      --with-pic
                     INSTALL_COMMAND ""
                     BUILD_IN_SOURCE 1)
                   

--- a/depends/common/vorbis/CMakeLists.txt
+++ b/depends/common/vorbis/CMakeLists.txt
@@ -1,6 +1,5 @@
+cmake_minimum_required(VERSION 3.5)
 project(vorbis)
-
-cmake_minimum_required(VERSION 2.8)
 
 include(ExternalProject)
 externalproject_add(vorbis

--- a/depends/common/vorbis/CMakeLists.txt
+++ b/depends/common/vorbis/CMakeLists.txt
@@ -12,7 +12,7 @@ externalproject_add(vorbis
                       --disable-examples
                       --enable-static
                       --disable-shared
-                      "CFLAGS=-fPIC -DPIC -O2"
+                      --with-pic
                     INSTALL_COMMAND ""
                     BUILD_IN_SOURCE 1)
                   

--- a/depends/windows/ogg/CMakeLists.txt
+++ b/depends/windows/ogg/CMakeLists.txt
@@ -1,6 +1,5 @@
+cmake_minimum_required(VERSION 3.5)
 project(libogg)
-
-cmake_minimum_required(VERSION 2.8)
 
 add_definitions(-DWIN32 -D_WINDOWS -D_USRDLL -DLIBOGG_EXPORTS)
 

--- a/depends/windows/vorbis/CMakeLists.txt
+++ b/depends/windows/vorbis/CMakeLists.txt
@@ -1,6 +1,5 @@
+cmake_minimum_required(VERSION 3.5)
 project(vorbis)
-
-cmake_minimum_required(VERSION 2.8)
 
 add_definitions(-DWIN32 -D_WINDOWS -D_USRDLL -DLIBVORBIS_EXPORTS)
 


### PR DESCRIPTION
@Rechi there is also a major bug with the pkg_check, without the second commit brings it:
```
        linux-vdso.so.1 (0x00007ffd11b28000)
        libogg.so.0 => /lib/x86_64-linux-gnu/libogg.so.0 (0x00007f3992a75000)
        libvorbis.so.0 => /lib/x86_64-linux-gnu/libvorbis.so.0 (0x00007f3992a48000)
        libvorbisenc.so.2 => /lib/x86_64-linux-gnu/libvorbisenc.so.2 (0x00007f399299d000)
        libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f39927bb000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f39927a1000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f39925b6000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f3992466000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f3992cb9000)
```
and use the OS libs (not from depends)

This after the fix:
```
        linux-vdso.so.1 (0x00007ffda6ed7000)
        libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007faf6a0e6000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007faf69f98000)
        libmvec.so.1 => /lib/x86_64-linux-gnu/libmvec.so.1 (0x00007faf69f6c000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007faf69f52000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007faf69d67000)
        /lib64/ld-linux-x86-64.so.2 (0x00007faf6a60a000)
```

Maybe a new release required.