### PR TITLE
fix debian override_dh_installdocs name

### DIFF
--- a/audioencoder.vorbis/addon.xml.in
+++ b/audioencoder.vorbis/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="audioencoder.vorbis"
-  version="3.0.0"
+  version="3.0.1"
   name="Vorbis Audio Encoder"
   provider-name="spiff">
   <requires>@ADDON_DEPENDS@</requires>

--- a/debian/rules
+++ b/debian/rules
@@ -16,5 +16,5 @@ override_dh_auto_configure:
 	dh_auto_configure -- -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS=1 -DUSE_LTO=1
 
 override_dh_installdocs:
-	dh_installdocs --link-doc=kodi-audioencoder-flac
+	dh_installdocs --link-doc=kodi-audioencoder-vorbis
 


### PR DESCRIPTION
Wrongly c&p from another one. Sh.. there I look some times over it and
still oversee something. Sorry!