### PR TITLE
[Leia] reduce build works

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
 matrix:
   include:
     - os: linux
-      dist: xenial
+      dist: focal
       sudo: required
       compiler: clang
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,7 @@ matrix:
     - os: linux
       dist: xenial
       sudo: required
-      compiler: gcc
-    - os: linux
-      dist: xenial
-      sudo: required
       compiler: clang
-    - os: osx
-      osx_image: xcode9.4
 
 #
 # The addon source is automatically checked out in $TRAVIS_BUILD_DIR,

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a [Kodi] (http://kodi.tv) Vorbis audio encoder add-on.
 
 #### CI Testing
-[![Build Status](https://travis-ci.org/xbmc/audioencoder.vorbis.svg?branch=master)](https://travis-ci.org/xbmc/audioencoder.vorbis)
+[![Build Status](https://travis-ci.com/xbmc/audioencoder.vorbis.svg?branch=master)](https://travis-ci.com/xbmc/audioencoder.vorbis)
 [![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.audioencoder.vorbis?branchName=Leia)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=23&branchName=Leia)
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/5120/badge.svg)](https://scan.coverity.com/projects/5120)
 


### PR DESCRIPTION
As there becomes soon a switch to the travis-ci.com where have time limitations are the OSX build and Linux gcc build removed.

The Linux clang language build stays.